### PR TITLE
fix: add release link to version footer in web interface

### DIFF
--- a/scripts/flask/templates/index.html
+++ b/scripts/flask/templates/index.html
@@ -137,7 +137,7 @@
   </div>
 
   <footer>
-    &copy; {{ year }} Geert Meersman. Version: <a target="_blank" href="https://github.com/geertmeersman/print-color-test/releases/tag/{{ version }}">{{ version }}</a>
+    &copy; {{ year }} Geert Meersman. Version: <a target="_blank" rel="noopener noreferrer" href="https://github.com/geertmeersman/print-color-test/releases/tag/{{ version }}">{{ version }}</a>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer version label is now a clickable link that opens the corresponding GitHub release in a new tab, making it easy to verify the app version and view release notes or downloads without leaving the app. Visual appearance of the version text remains unchanged. No other visible changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->